### PR TITLE
Fix action URL

### DIFF
--- a/.github/workflows/gh-action-upload.yml
+++ b/.github/workflows/gh-action-upload.yml
@@ -25,4 +25,4 @@ jobs:
             --form file=@addons/resource.language.en_gb/resources/strings.po \
             --form method=source \
             -H "Authorization: Token $TOKEN" \
-            http://kodi.weblate.cloud/api/translations/kodi-core/kodi-main/en_gb/file/
+            https://kodi.weblate.cloud/api/translations/kodi-core/kodi-main/en_gb/file/


### PR DESCRIPTION
When using http, all what happens is that CURL gets "301 Moved Permanently", see https://github.com/gade01/xbmc/runs/1315618409?check_suite_focus=true#step:3:17